### PR TITLE
Allow BdSpiderMastermind to be crushed in Doom 2 MAP06

### DIFF
--- a/pk3/decorate/monsters/Mastermind.txt
+++ b/pk3/decorate/monsters/Mastermind.txt
@@ -22,7 +22,6 @@ ACTOR BdSpiderMastermind : BdLiteMonster Replaces SpiderMastermind
     +NORADIUSDMG
     +NOBLOOD
     +MISSILEMORE
-    -SOLID
     +MISSILEEVENMORE
     +SHOOTABLE
     SeeSound "spider/sight"


### PR DESCRIPTION
Monsters marked as not solid using the -SOLID flag do not appear to receive crush damage in latest tested version of GZDoom (4.5.0). The BdSpiderMastermind has the -SOLID flag, meaning that it would not be crushed in Doom 2's MAP06 - The Crusher, breaking the map. This pull request simply fixes this error and allows the Spider Mastermind to be killed using the crusher in MAP06, as the Doom 2 designers originally intended.